### PR TITLE
Use of `num-parse` to parse integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Current main branch.
 
 - General
-  - Moved `macros` into separate repository [tokay-macros](https://github.com/tokay-lang/tokay-macros)
+  - Use of numeric parsing features from [num-parse](https://crates.io/crates/num-parse) for `Int` and internal string-to-int conversion ("parseInt()"-like behavior)
 - Syntax
   - Improved syntax for inline blocks and sequences (`|`-operator)
   - Improved list syntax

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,8 @@ dependencies = [
 [[package]]
 name = "num-parse"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0c36742cfeb51f2f71290eca9fc15d0e024a649a552c64707b39b8584991a1"
 dependencies = [
  "num",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.5"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.5"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "ghost"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c813ffb63e8fd3df6f1ac3cc1ea392c7612ac2de4d0b44dcbfe03e5c4bf94a"
+checksum = "b93490550b1782c589a350f2211fff2e34682e25fed17ef53fc4fa8fe184975e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -205,9 +205,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
 ]
@@ -365,18 +365,18 @@ dependencies = [
 
 [[package]]
 name = "num-parse"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0c36742cfeb51f2f71290eca9fc15d0e024a649a552c64707b39b8584991a1"
+checksum = "74203a72494483a16b7fa9301726dffac4b3de7d32a2ef8693c29c8527eb11ee"
 dependencies = [
  "num",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
@@ -431,18 +431,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -509,9 +509,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "str-buf"
@@ -533,9 +533,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,7 +602,7 @@ name = "tokay"
 version = "0.6.0"
 dependencies = [
  "charclass",
- "clap 3.2.5",
+ "clap 3.2.8",
  "glob",
  "indexmap",
  "num",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-segmentation"
@@ -661,9 +661,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-parse"
+version = "0.1.0"
+dependencies = [
+ "num",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +605,7 @@ dependencies = [
  "indexmap",
  "num",
  "num-bigint",
+ "num-parse",
  "rustyline",
  "tokay 0.4.0",
  "tokay-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ num-bigint = "0.4"
 rustyline = "8.2"
 #tokay-macros = "0.2"
 tokay-macros = { version = "0.2", path = "macros" }
+num-parse = { version = "0.1", path = "../num-parse" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ num-bigint = "0.4"
 rustyline = "8.2"
 #tokay-macros = "0.2"
 tokay-macros = { version = "0.2", path = "macros" }
-num-parse = { version = "0.1", path = "../num-parse" }
+num-parse = "0.1"
+#num-parse = { version = "0.1", path = "../num-parse" }

--- a/src/value/str.rs
+++ b/src/value/str.rs
@@ -3,6 +3,7 @@ use super::{BoxedObject, List, Object, RefValue};
 use crate::value;
 use num::Zero;
 use num_bigint::BigInt;
+use num_parse::*;
 use tokay_macros::tokay_method;
 extern crate self as tokay;
 
@@ -43,11 +44,7 @@ impl Object for Str {
     }
 
     fn to_i64(&self) -> Result<i64, String> {
-        // todo: JavaScript-style parseInt-like behavior?
-        match self.string.parse::<i64>() {
-            Ok(i) => Ok(i),
-            Err(_) => Ok(0),
-        }
+        Ok(parse_int::<i64>(&self.string).unwrap_or(0))
     }
 
     fn to_f64(&self) -> Result<f64, String> {
@@ -59,11 +56,7 @@ impl Object for Str {
     }
 
     fn to_usize(&self) -> Result<usize, String> {
-        // todo: JavaScript-style parseInt-like behavior?
-        match self.string.parse::<usize>() {
-            Ok(i) => Ok(i),
-            Err(_) => Ok(0),
-        }
+        Ok(parse_uint::<usize>(&self.string).unwrap_or(0))
     }
 
     fn to_string(&self) -> String {
@@ -71,23 +64,7 @@ impl Object for Str {
     }
 
     fn to_bigint(&self) -> Result<BigInt, String> {
-        // JavaScript parseInt-style prefix parsing
-        let mut ret = BigInt::zero();
-        let mut neg = false;
-
-        for (i, digit) in self.string.trim().chars().enumerate() {
-            if i == 0 && (digit == '+' || digit == '-') {
-                neg = digit == '-';
-                continue;
-            }
-
-            match digit.to_digit(10) {
-                Some(digit) => ret = ret * 10 + digit,
-                None => break,
-            }
-        }
-
-        Ok(if neg { -ret } else { ret })
+        Ok(parse_int::<BigInt>(&self.string).unwrap_or(BigInt::zero()))
     }
 }
 

--- a/src/value/token.rs
+++ b/src/value/token.rs
@@ -269,9 +269,9 @@ tokay_token!("Int(base=void, with_signs=true)", {
     };
 
     if let Some(int) = if with_signs.is_true() {
-        parse_int_from_iter_with_radix::<BigInt>(context.runtime.reader, base)
+        parse_int_from_iter_with_radix::<BigInt>(context.runtime.reader, base, false)
     } else {
-        parse_uint_from_iter_with_radix::<BigInt>(context.runtime.reader, base)
+        parse_uint_from_iter_with_radix::<BigInt>(context.runtime.reader, base, false)
     } {
         Ok(Accept::Push(Capture::Value(crate::value!(int), None, 5)))
     } else {

--- a/src/value/token.rs
+++ b/src/value/token.rs
@@ -4,6 +4,7 @@ use crate::reader::Reader;
 use crate::vm::*;
 use charclass::{charclass, CharClass};
 use num_bigint::BigInt;
+use num_parse::*;
 use tokay_macros::tokay_token;
 extern crate self as tokay;
 
@@ -79,7 +80,7 @@ impl Token {
                 }
             }
             Token::Char(ccl) => {
-                if let Some(ch) = reader.take(|ch| ccl.test(&(ch..=ch))) {
+                if let Some(ch) = reader.once(|ch| ccl.test(&(ch..=ch))) {
                     return Ok(Accept::Push(Capture::Range(
                         reader.capture_last(ch.len_utf8()),
                         None,
@@ -90,7 +91,7 @@ impl Token {
                 Err(Reject::Next)
             }
             Token::BuiltinChar(f) => {
-                if let Some(ch) = reader.take(f) {
+                if let Some(ch) = reader.once(f) {
                     return Ok(Accept::Push(Capture::Range(
                         reader.capture_last(ch.len_utf8()),
                         None,
@@ -104,7 +105,7 @@ impl Token {
                 let start = reader.tell();
 
                 while let Some(ch) = reader.peek() {
-                    if !ccl.test(&(ch..=ch)) {
+                    if !ccl.test(&(*ch..=*ch)) {
                         break;
                     }
 
@@ -124,7 +125,7 @@ impl Token {
                 let start = reader.tell();
 
                 while let Some(ch) = reader.peek() {
-                    if !f(ch) {
+                    if !f(*ch) {
                         break;
                     }
 
@@ -145,7 +146,7 @@ impl Token {
 
                 for ch in string.chars() {
                     if let Some(c) = reader.peek() {
-                        if c != ch {
+                        if *c != ch {
                             break;
                         }
                     } else {
@@ -235,7 +236,7 @@ tokay_token!("Ident", {
     let reader = &mut context.runtime.reader;
     let start = reader.tell();
 
-    if reader.take(|ch| ch.is_alphabetic() || ch == '_').is_none() {
+    if reader.once(|ch| ch.is_alphabetic() || ch == '_').is_none() {
         return Err(Reject::Next);
     }
 
@@ -249,44 +250,33 @@ tokay_token!("Ident", {
 });
 
 // Matching 64-bit integers directly
-tokay_token!("Int(base=10, with_signs=true)", {
-    let reader = &mut context.runtime.reader;
-
+tokay_token!("Int(base=void, with_signs=true)", {
     // Digits
-    let base = base.to_i64()?;
-    if base < 1 || base > 36 {
-        // maximum radix = 10 digits + 26 letters
-        return Err(format!(
-            "{} base value is {}, allowed is only between 1 and 36",
-            __function, base
-        )
-        .into());
-    }
-
-    // Sign
-    let mut neg = false;
-
-    if with_signs.is_true() {
-        if let Some(ch) = reader.take(|ch: char| ch == '-' || ch == '+') {
-            neg = ch == '-'
-        }
-    }
-
-    if let Some(input) = reader.span(|ch: char| ch.is_digit(base as u32)) {
-        let mut value = BigInt::from(0);
-
-        for dig in input.chars() {
-            value = value * base + dig.to_digit(base as u32).unwrap() as i64;
+    let base = if base.is_void() {
+        None
+    } else {
+        let base = base.to_i64()?;
+        if base < 1 || base > 36 {
+            // maximum radix = 10 digits + 26 letters
+            return Err(format!(
+                "{} base value is {}, allowed is only between 1 and 36",
+                __function, base
+            )
+            .into());
         }
 
-        return Ok(Accept::Push(Capture::Value(
-            crate::value!(if neg { -value } else { value }),
-            None,
-            5,
-        )));
-    }
+        Some(base as u32)
+    };
 
-    Err(Reject::Next)
+    if let Some(int) = if with_signs.is_true() {
+        parse_int_from_iter_with_radix::<BigInt>(context.runtime.reader, base)
+    } else {
+        parse_uint_from_iter_with_radix::<BigInt>(context.runtime.reader, base)
+    } {
+        Ok(Accept::Push(Capture::Value(crate::value!(int), None, 5)))
+    } else {
+        Err(Reject::Next)
+    }
 });
 
 // Matching 64-bit floats directly
@@ -296,14 +286,14 @@ tokay_token!("Float(with_signs=true)", {
 
     // Sign
     if with_signs.is_true() {
-        reader.take(|ch: char| ch == '-' || ch == '+');
+        reader.once(|ch: char| ch == '-' || ch == '+');
     }
 
     // Integer part
     let has_int = reader.span(|ch: char| ch.is_numeric()).is_some();
 
     // Decimal point
-    if reader.take(|ch: char| ch == '.').is_none() {
+    if reader.once(|ch: char| ch == '.').is_none() {
         return Err(Reject::Next);
     }
 
@@ -316,8 +306,8 @@ tokay_token!("Float(with_signs=true)", {
     let mut range = reader.capture_from(&start);
 
     // Exponential notation
-    if reader.take(|ch: char| ch == 'e' || ch == 'E').is_some() {
-        reader.take(|ch: char| ch == '-' || ch == '+');
+    if reader.once(|ch: char| ch == 'e' || ch == 'E').is_some() {
+        reader.once(|ch: char| ch == '-' || ch == '+');
 
         if reader.span(|ch: char| ch.is_numeric()).is_some() {
             // Extend range when exponentional value could be read!


### PR DESCRIPTION
The [`num-parse`-crate](https://crates.io/crates/num-parse) was established from the requirement that there is no existing JavaScript-like `parseInt()` or `parseFloat()` method in Rust.

This crate is developed apart from Tokay, but Tokay makes both use of it in terms of the internal string-to-int-conversion functions as well as the `Int`-token. For this case, the `Reader` needed to be modified to implement `PeekableIterator` from `num-parse` to use equal parsing features in all cases.

`num-parse` will be extended to support a `parse_float()` as well, which will be integrated into Tokay as well then.