### PR TITLE
Parseable sequences with in-place reader extend

### DIFF
--- a/examples/tokay.tok
+++ b/examples/tokay.tok
@@ -243,10 +243,11 @@ TokenLiteral : @{
 
 TokenAtom : @{
     TokenLiteral
+    InlineBlock
+    '@' _ InlineBlock  ast("area")
+    Block
     ParseletInstance '(' _ ___ CallArguments? ___ expect ')'  ast("call")
     ParseletInstance
-    InlineBlock
-    Block
 }
 
 Token1 : @{  # todo: Token1 can be renamed back to Token again when #31 is fixed and Self is used.

--- a/src/compiler/ast.rs
+++ b/src/compiler/ast.rs
@@ -1424,7 +1424,8 @@ fn traverse_node(compiler: &mut Compiler, node: &Dict) -> ImlOp {
             // In most cases, lists are parsed as sequences;
             // inline-sequence always have a higher return severity.
             else {
-                ImlOp::seq(ops, true)
+                let extend = emit == "inline_sequence" && ops.iter().any(|op| op.is_consuming());
+                ImlOp::seq(ops, Some(extend))
             }
         }
 
@@ -1501,7 +1502,7 @@ tokay_function!("ast(emit, value=void, flatten=true, debug=false)", {
     ret.insert("emit".to_string(), emit.clone());
 
     // Need current frame position
-    let capture_start = context.frame0().capture_start;
+    let capture_start = context.frame.capture_start;
 
     let value = if value.is_void() {
         Some(
@@ -1543,7 +1544,7 @@ tokay_function!("ast(emit, value=void, flatten=true, debug=false)", {
         }
     }
 
-    let reader_start = context.frame0().reader_start;
+    let reader_start = context.frame.reader_start;
 
     // Store positions of reader start
     ret.insert(

--- a/src/compiler/ast.rs
+++ b/src/compiler/ast.rs
@@ -644,6 +644,12 @@ fn traverse_node(compiler: &mut Compiler, node: &Dict) -> ImlOp {
             ImlOp::from(vec![expr, alias, ImlOp::from(Op::MakeAlias)])
         }
 
+        // area -----------------------------------------------------------
+        "area" => {
+            let body = traverse(compiler, &node["children"]);
+            ImlOp::seq(vec![body, ImlOp::from(Op::Extend)], false)
+        }
+
         // assign ---------------------------------------------------------
         assign if assign.starts_with("assign") => {
             let children = node["children"].borrow();
@@ -1416,16 +1422,14 @@ fn traverse_node(compiler: &mut Compiler, node: &Dict) -> ImlOp {
                 ));
             }
 
-            // Lists are definitive lists with a given length
+            // Lists are definitive lists with a given length and only non-aliased values
             if emit == "list" {
                 ops.push(Op::MakeList(children.len()).into());
                 ImlOp::from(ops)
             }
             // In most cases, lists are parsed as sequences;
-            // inline-sequence always have a higher return severity.
             else {
-                let extend = emit == "inline_sequence" && ops.iter().any(|op| op.is_consuming());
-                ImlOp::seq(ops, Some(extend))
+                ImlOp::seq(ops, true)
             }
         }
 

--- a/src/compiler/iml/op.rs
+++ b/src/compiler/iml/op.rs
@@ -76,7 +76,9 @@ pub(in crate::compiler) enum ImlOp {
     // Sequence of ops, optionally a collection
     Seq {
         seq: Vec<ImlOp>,
-        collection: Option<bool>, // Sequence is constructed as a collection, with optional reader extend of outer frame
+        collection: bool, /* According to these operation's semantics, or when an entire sequence is completely recognized,
+                          the sequence is getting accepted. Incomplete sequences are rejected, but might partly be
+                          processed, including data changes, which is a wanted behavior. */
     },
 
     // Conditional block
@@ -123,14 +125,14 @@ pub(in crate::compiler) enum ImlOp {
 
 impl ImlOp {
     /// Creates a sequence from items, and optimizes stacked, unframed sequences
-    pub fn seq(items: Vec<ImlOp>, collection: Option<bool>) -> ImlOp {
+    pub fn seq(items: Vec<ImlOp>, collection: bool) -> ImlOp {
         let mut seq = Vec::new();
 
         for item in items {
             match item {
                 ImlOp::Nop => {}
                 ImlOp::Seq {
-                    collection: None,
+                    collection: false,
                     seq: items,
                 } => seq.extend(items),
                 item => seq.push(item),
@@ -139,7 +141,7 @@ impl ImlOp {
 
         match seq.len() {
             0 => ImlOp::Nop,
-            1 if collection.is_none() => seq.pop().unwrap(),
+            1 if !collection => seq.pop().unwrap(),
             _ => ImlOp::Seq { seq, collection },
         }
     }
@@ -441,22 +443,16 @@ impl ImlOp {
                 }
 
                 // Check if the sequence exists of more than one operational instruction
-                if ops[start..]
-                    .iter()
-                    .map(|op| if matches!(op, Op::Offset(_)) { 0 } else { 1 })
-                    .sum::<usize>()
-                    > 1
+                if *collection
+                    && ops[start..]
+                        .iter()
+                        .map(|op| if matches!(op, Op::Offset(_)) { 0 } else { 1 })
+                        .sum::<usize>()
+                        > 1
                 {
-                    // Create a frame and collect in collection-mode
-                    if let Some(extend) = collection {
-                        ops.insert(start, Op::Frame(0));
-                        ops.push(Op::Collect);
-                        ops.push(Op::Close);
-
-                        if *extend {
-                            ops.push(Op::Extend);
-                        }
-                    }
+                    ops.insert(start, Op::Frame(0));
+                    ops.push(Op::Collect);
+                    ops.push(Op::Close);
                 }
             }
             ImlOp::If {
@@ -916,6 +912,6 @@ impl From<Op> for ImlOp {
 
 impl From<Vec<ImlOp>> for ImlOp {
     fn from(items: Vec<ImlOp>) -> Self {
-        ImlOp::seq(items, None)
+        ImlOp::seq(items, false)
     }
 }

--- a/src/compiler/macros.rs
+++ b/src/compiler/macros.rs
@@ -157,7 +157,7 @@ macro_rules! tokay {
                     .filter(|item| item.is_some())
                     .map(|item| item.unwrap())
                     .collect(),
-                    Some(false)
+                    true
                 )
             )
         }

--- a/src/compiler/macros.rs
+++ b/src/compiler/macros.rs
@@ -157,7 +157,7 @@ macro_rules! tokay {
                     .filter(|item| item.is_some())
                     .map(|item| item.unwrap())
                     .collect(),
-                    true
+                    Some(false)
                 )
             )
         }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -290,11 +290,12 @@ impl Parser {
 
         (TokenAtom = {
             TokenLiteral,
+            InlineBlock,
+            ["@", _, InlineBlock, (call ast[(value "area")])],
+            Block,
             [ParseletInstance, "(", _, ___, (opt CallArguments), ___, (expect ")"),
                 (call ast[(value "call")])],
-            ParseletInstance,
-            InlineBlock,
-            Block
+            ParseletInstance
         }),
 
         (Token = {

--- a/src/test.rs
+++ b/src/test.rs
@@ -640,8 +640,9 @@ fn examples() {
         Ok(Some(value!(24)))
     );
 
-    // todo: Move this to a separate function
+    // todo: Move stuff below to a separate function
     testcase("tests/test_piped_grammar.tok");
+    testcase("tests/test_inline_parseable_sequence.tok");
 }
 
 // Tests for control flow -------------------------------------------------------------------------

--- a/src/vm/context.rs
+++ b/src/vm/context.rs
@@ -128,17 +128,21 @@ impl<'runtime, 'program, 'reader, 'parselet> Context<'runtime, 'program, 'reader
         self.push(value)
     }
 
-    // Return current frame
-    pub fn frame(&self) -> &Frame {
-        &self.frame
-    }
-
-    // Return top-level frame
+    /// Return top-level frame
     pub fn frame0(&self) -> &Frame {
         if self.frames.is_empty() {
             &self.frame
         } else {
             &self.frames[0]
+        }
+    }
+
+    /// Return mutable top-level frame
+    pub fn frame0_mut(&mut self) -> &mut Frame {
+        if self.frames.is_empty() {
+            &mut self.frame
+        } else {
+            &mut self.frames[0]
         }
     }
 

--- a/src/vm/op.rs
+++ b/src/vm/op.rs
@@ -22,7 +22,8 @@ pub(crate) enum Op {
 
     // Capture frames
     Frame(usize), // Start new frame with optional relative forward address fuse
-    Commit,       // Commit frame
+    Capture,      // Reset frame capture to current stack size, saving captures
+    Extend,       // Extend frame's reader to current position
     Reset,        // Reset frame
     Close,        // Close frame
     Collect,      // Collect stack values from current frame
@@ -194,8 +195,12 @@ impl Op {
                     Ok(Accept::Next)
                 }
 
-                Op::Commit => {
+                Op::Capture => {
                     context.frame.capture_start = context.runtime.stack.len();
+                    Ok(Accept::Next)
+                }
+
+                Op::Extend => {
                     context.frame.reader_start = context.runtime.reader.tell();
                     Ok(Accept::Next)
                 }

--- a/tests/test_inline_parseable_sequence.tok
+++ b/tests/test_inline_parseable_sequence.tok
@@ -1,0 +1,10 @@
+print("stage 1 " + repr(x))
+#Int _ x = (Int expect EOF  ast("test")) ast("yo")
+x = (Int _ Int ast("test"))
+print("stage 2 " + repr(x))
+#end x
+#---
+#1 2
+#---
+#stage 1 void
+#stage 2 (emit => "test", children => (1, 2), offset => 0, row => 1, col => 1, stop_offset => 3, stop_row => 1, stop_col => 4)

--- a/tests/test_inline_parseable_sequence.tok
+++ b/tests/test_inline_parseable_sequence.tok
@@ -1,6 +1,6 @@
 print("stage 1 " + repr(x))
 #Int _ x = (Int expect EOF  ast("test")) ast("yo")
-x = (Int _ Int ast("test"))
+x = @(Int _ Int ast("test") | Void)
 print("stage 2 " + repr(x))
 #end x
 #---


### PR DESCRIPTION
This makes all inline-sequences consuming input to areas with an in-place reader extend, which avoid the outer frame to break because input is not indicated to be parsed.

This program works with [9ec2b66](https://github.com/tokay-lang/tokay/pull/78/commits/9ec2b66c68ab382fb32565c350557a1d50adc5cc) with input `1 2`
```tokay
print("stage 1 " + repr(x))
x = (Int _ Int ast("test"))
print("stage 2 " + repr(x))
```
Nevertheless, programs like
```tokay
(Int ',' Int) | Ident   # will accept: 1,2a
```
will accept inputs like `1,2a`, which is obviously not a wanted behavior.

Maybe it's better to introduce a new syntactic construct like a `@(...)` area, which creates a sequence as an in-place parse-able area.

This PR relates to #76 as initial issue.