### PR TITLE
Implement `divi` (integer divison) operations / operators `//` and `//=`

### DIFF
--- a/examples/tokay.tok
+++ b/examples/tokay.tok
@@ -304,6 +304,7 @@ Unary : @{
 
 MulDiv : @{
     MulDiv '*' _ expect Unary  ast("op_binary_mul")
+    MulDiv '//' _ expect Unary  ast("op_binary_divi")
     MulDiv '/' _ expect Unary  ast("op_binary_div")
     MulDiv '%' _ expect Unary  ast("op_binary_mul")
     Unary
@@ -340,6 +341,7 @@ HoldExpression : @{
     Lvalue _ '-=' _ expect HoldExpression  ast("assign_sub_hold")
     Lvalue _ '*=' _ expect HoldExpression  ast("assign_mul_hold")
     Lvalue _ '/=' _ expect HoldExpression  ast("assign_div_hold")
+    Lvalue _ '//=' _ expect HoldExpression  ast("assign_divi_hold")
     Lvalue _ '%=' _ expect HoldExpression  ast("assign_mod_hold")
     Lvalue _ '=' not ('>' | '=') _ expect HoldExpression  ast("assign_hold")
     LogicalOr
@@ -350,6 +352,7 @@ Expression : @{
     Lvalue _ '-=' _ expect HoldExpression  ast("assign_sub")
     Lvalue _ '*=' _ expect HoldExpression  ast("assign_mul")
     Lvalue _ '/=' _ expect HoldExpression  ast("assign_div")
+    Lvalue _ '//=' _ expect HoldExpression  ast("assign_divi")
     Lvalue _ '%=' _ expect HoldExpression  ast("assign_mod")
     Lvalue _ '=' not ('>' | '=') _ expect HoldExpression  ast("assign")
     LogicalOr

--- a/src/compiler/ast.rs
+++ b/src/compiler/ast.rs
@@ -670,6 +670,7 @@ fn traverse_node(compiler: &mut Compiler, node: &Dict) -> ImlOp {
                     "sub" => ImlOp::from(Op::BinaryOp("isub")),
                     "mul" => ImlOp::from(Op::BinaryOp("imul")),
                     "div" => ImlOp::from(Op::BinaryOp("idiv")),
+                    "divi" => ImlOp::from(Op::BinaryOp("idivi")),
                     "mod" => ImlOp::from(Op::BinaryOp("imod")),
                     _ => unreachable!(),
                 });
@@ -1115,6 +1116,7 @@ fn traverse_node(compiler: &mut Compiler, node: &Dict) -> ImlOp {
                                 "sub" => Op::BinaryOp("sub"),
                                 "mul" => Op::BinaryOp("mul"),
                                 "div" => Op::BinaryOp("div"),
+                                "divi" => Op::BinaryOp("divi"),
                                 "mod" => Op::BinaryOp("mod"),
                                 "eq" => Op::BinaryOp("eq"),
                                 "neq" => Op::BinaryOp("neq"),

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -368,6 +368,7 @@ impl Parser {
 
         (MulDiv = {
             [MulDiv, "*", _, (expect Unary), (call ast[(value "op_binary_mul")])],
+            [MulDiv, "//", _, (expect Unary), (call ast[(value "op_binary_divi")])],
             [MulDiv, "/", _, (expect Unary), (call ast[(value "op_binary_div")])],
             [MulDiv, "%", _, (expect Unary), (call ast[(value "op_binary_mod")])],
             Unary
@@ -408,6 +409,7 @@ impl Parser {
             [Lvalue, _, "-=", _, (expect HoldExpression), (call ast[(value "assign_sub_hold")])],
             [Lvalue, _, "*=", _, (expect HoldExpression), (call ast[(value "assign_mul_hold")])],
             [Lvalue, _, "/=", _, (expect HoldExpression), (call ast[(value "assign_div_hold")])],
+            [Lvalue, _, "//=", _, (expect HoldExpression), (call ast[(value "assign_divi_hold")])],
             [Lvalue, _, "%=", _, (expect HoldExpression), (call ast[(value "assign_mod_hold")])],
             [Lvalue, _, "=", (not {">", "="}), //avoid wrongly matching "=>" or "=="
                 _, (expect HoldExpression), (call ast[(value "assign_hold")])],
@@ -422,6 +424,7 @@ impl Parser {
             [Lvalue, _, "-=", _, (expect HoldExpression), (call ast[(value "assign_sub")])],
             [Lvalue, _, "*=", _, (expect HoldExpression), (call ast[(value "assign_mul")])],
             [Lvalue, _, "/=", _, (expect HoldExpression), (call ast[(value "assign_div")])],
+            [Lvalue, _, "//=", _, (expect HoldExpression), (call ast[(value "assign_divi")])],
             [Lvalue, _, "%=", _, (expect HoldExpression), (call ast[(value "assign_mod")])],
             [Lvalue, _, "=", (not {">", "="}), //avoid wrongly matching "=>" or "==" here
                 _, (expect HoldExpression), (call ast[(value "assign")])],

--- a/src/value/refvalue.rs
+++ b/src/value/refvalue.rs
@@ -190,7 +190,7 @@ impl RefValue {
                         }
                     }
 
-                    (Value::Float(_), _) | (_, Value::Float(_)) => match op {
+                    (Value::Float(_), _) | (_, Value::Float(_)) if op != "divi" => match op {
                         "add" => return Ok(value!(this.to_f64()? + that.to_f64()?)),
                         "mul" => return Ok(value!(this.to_f64()? * that.to_f64()?)),
                         "sub" => return Ok(value!(this.to_f64()? - that.to_f64()?)),
@@ -201,8 +201,7 @@ impl RefValue {
                             if divisor == 0.0 {
                                 if op == "mod" {
                                     return Err(String::from("Modulo by zero"));
-                                }
-                                else {
+                                } else {
                                     return Err(String::from("Division by zero"));
                                 }
                             }
@@ -220,17 +219,20 @@ impl RefValue {
                         "add" => return Ok(value!(this.to_bigint()? + that.to_bigint()?)),
                         "mul" => return Ok(value!(this.to_bigint()? * that.to_bigint()?)),
                         "sub" => return Ok(value!(this.to_bigint()? - that.to_bigint()?)),
-                        "div" | "mod" => {
+                        "div" | "divi" | "mod" => {
                             let dividend = this.to_bigint()?;
                             let divisor = that.to_bigint()?;
 
                             if divisor.is_zero() {
                                 if op == "mod" {
                                     return Err(String::from("Modulo by zero"));
-                                }
-                                else {
+                                } else {
                                     return Err(String::from("Division by zero"));
                                 }
+                            }
+
+                            if op == "divi" {
+                                return Ok(value!(dividend / divisor));
                             }
 
                             let modres = &dividend % &divisor;
@@ -242,8 +244,7 @@ impl RefValue {
                                 } else {
                                     return Ok(value!(dividend / divisor));
                                 }
-                            }
-                            else if op == "mod" {
+                            } else if op == "mod" {
                                 return Ok(value!(modres));
                             }
                             // Otherwise do a floating point division

--- a/tests/binary_op_divi.tok
+++ b/tests/binary_op_divi.tok
@@ -1,0 +1,60 @@
+#testmode:repl
+# Tests for the integer div function in various situations
+
+true // false
+true // true
+10 // 20
+10.5 // 20
+23 // 5
+25 // 5
+29.5 // 5
+10 // "20"
+a = 100
+b = 1000
+a // b
+b // a
+"a" // "b"
+
+x = 7 for i = 1; i <= 7; i++ { print(i, x // i, type(x // i)) }
+
+x = 7. for i = 1; i <= 7; i++ { print(i, x // i, type(x // i)) }
+
+x = 7 for i = 1.; i <= 7.; i++ { print(i, x // i, type(x // i)) }
+
+#---
+
+#ERR:Line 1, column 1: Division by zero
+#1
+#0
+#0
+#4
+#5
+#5
+#ERR:Line 1, column 1: Method 'str_divi' not found
+#0
+#10
+#ERR:Line 1, column 1: Method 'str_divi' not found
+
+#1 7 int
+#2 3 int
+#3 2 int
+#4 1 int
+#5 1 int
+#6 1 int
+#7 1 int
+
+#1 7 int
+#2 3 int
+#3 2 int
+#4 1 int
+#5 1 int
+#6 1 int
+#7 1 int
+
+#1 7 int
+#2 3 int
+#3 2 int
+#4 1 int
+#5 1 int
+#6 1 int
+#7 1 int


### PR DESCRIPTION
- Better have this pull request instead of trying 02a98bec96c68e49470e1a8ad2e3ecb9f9dd2b23 to 0cc6e4156be433d4a22029d9371e97c6919c2889 quickly 3b7b72660cf1ff4f69db3868ffb87f9af675ff82 implement other operators...
- wasn't able to implemnt `idiv` as operation name with an `i` in prefix has a special meaning as "inline". This implementation should also be reconsidered.