### PR TITLE
Implement character-classes by `Char<...>` keyword token

### DIFF
--- a/src/compiler/ast.rs
+++ b/src/compiler/ast.rs
@@ -14,7 +14,7 @@ use charclass::CharClass;
 /// Checks whether identifier's name is the name of a reserved word.
 pub fn identifier_is_valid(ident: &str) -> Result<(), Error> {
     match ident {
-        "accept" | "begin" | "break" | "continue" | "else" | "end" | "exit" | "expect"
+        "Char" | "accept" | "begin" | "break" | "continue" | "else" | "end" | "exit" | "expect"
         | "false" | "for" | "if" | "in" | "loop" | "next" | "not" | "null" | "peek" | "push"
         | "reject" | "repeat" | "return" | "true" | "void" => Err(Error::new(
             None,

--- a/src/compiler/gen_parser/Makefile
+++ b/src/compiler/gen_parser/Makefile
@@ -1,5 +1,10 @@
 .PHONY: .FORCE
 
-../parser.rs: .FORCE
+PARSER=../parser.rs
+
+$(PARSER): .FORCE
 	awk -f etareneg.awk $@ >$@.1
 	mv $@.1 $@
+
+reset:
+	git checkout $(PARSER)

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1576,14 +1576,8 @@ impl Parser {
                                                                     "emit" => "ccl_neg",
                                                                     "children" =>
                                                                         (value!([
-                                                                            (value!([
-                                                                                "emit" => "char",
-                                                                                "value" => "]"
-                                                                            ])),
-                                                                            (value!([
-                                                                                "emit" => "char",
-                                                                                "value" => ">"
-                                                                            ]))
+                                                                            "emit" => "char",
+                                                                            "value" => ">"
                                                                         ]))
                                                                 ]))
                                                         ])),
@@ -3615,42 +3609,6 @@ impl Parser {
                                                                 (value!([
                                                                     (value!([
                                                                         "emit" => "value_token_touch",
-                                                                        "value" => "["
-                                                                    ])),
-                                                                    (value!([
-                                                                        "emit" => "identifier",
-                                                                        "value" => "Ccl"
-                                                                    ])),
-                                                                    (value!([
-                                                                        "emit" => "value_token_touch",
-                                                                        "value" => "]"
-                                                                    ])),
-                                                                    (value!([
-                                                                        "emit" => "call",
-                                                                        "children" =>
-                                                                            (value!([
-                                                                                (value!([
-                                                                                    "emit" => "identifier",
-                                                                                    "value" => "ast"
-                                                                                ])),
-                                                                                (value!([
-                                                                                    "emit" => "callarg",
-                                                                                    "children" =>
-                                                                                        (value!([
-                                                                                            "emit" => "value_string",
-                                                                                            "value" => "value_token_ccl"
-                                                                                        ]))
-                                                                                ]))
-                                                                            ]))
-                                                                    ]))
-                                                                ]))
-                                                        ])),
-                                                        (value!([
-                                                            "emit" => "sequence",
-                                                            "children" =>
-                                                                (value!([
-                                                                    (value!([
-                                                                        "emit" => "value_token_touch",
                                                                         "value" => "Char"
                                                                     ])),
                                                                     (value!([
@@ -3695,7 +3653,7 @@ impl Parser {
                                                                 (value!([
                                                                     (value!([
                                                                         "emit" => "value_token_touch",
-                                                                        "value" => "."
+                                                                        "value" => "Char"
                                                                     ])),
                                                                     (value!([
                                                                         "emit" => "call",
@@ -7579,7 +7537,7 @@ impl Parser {
                                                                 (value!([
                                                                     (value!([
                                                                         "emit" => "value_token_any",
-                                                                        "value" => "."
+                                                                        "value" => "Char"
                                                                     ])),
                                                                     (value!([
                                                                         "emit" => "call",

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -920,8 +920,8 @@ impl Parser {
                                                                 ]))
                                                         ])),
                                                         (value!([
-                                                            "emit" => "identifier",
-                                                            "value" => "Any"
+                                                            "emit" => "value_token_any",
+                                                            "value" => "Char"
                                                         ]))
                                                     ]))
                                             ]))

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -1576,8 +1576,14 @@ impl Parser {
                                                                     "emit" => "ccl_neg",
                                                                     "children" =>
                                                                         (value!([
-                                                                            "emit" => "char",
-                                                                            "value" => "]"
+                                                                            (value!([
+                                                                                "emit" => "char",
+                                                                                "value" => "]"
+                                                                            ])),
+                                                                            (value!([
+                                                                                "emit" => "char",
+                                                                                "value" => ">"
+                                                                            ]))
                                                                         ]))
                                                                 ]))
                                                         ])),
@@ -3609,34 +3615,6 @@ impl Parser {
                                                                 (value!([
                                                                     (value!([
                                                                         "emit" => "value_token_touch",
-                                                                        "value" => "."
-                                                                    ])),
-                                                                    (value!([
-                                                                        "emit" => "call",
-                                                                        "children" =>
-                                                                            (value!([
-                                                                                (value!([
-                                                                                    "emit" => "identifier",
-                                                                                    "value" => "ast"
-                                                                                ])),
-                                                                                (value!([
-                                                                                    "emit" => "callarg",
-                                                                                    "children" =>
-                                                                                        (value!([
-                                                                                            "emit" => "value_string",
-                                                                                            "value" => "value_token_any"
-                                                                                        ]))
-                                                                                ]))
-                                                                            ]))
-                                                                    ]))
-                                                                ]))
-                                                        ])),
-                                                        (value!([
-                                                            "emit" => "sequence",
-                                                            "children" =>
-                                                                (value!([
-                                                                    (value!([
-                                                                        "emit" => "value_token_touch",
                                                                         "value" => "["
                                                                     ])),
                                                                     (value!([
@@ -3661,6 +3639,78 @@ impl Parser {
                                                                                         (value!([
                                                                                             "emit" => "value_string",
                                                                                             "value" => "value_token_ccl"
+                                                                                        ]))
+                                                                                ]))
+                                                                            ]))
+                                                                    ]))
+                                                                ]))
+                                                        ])),
+                                                        (value!([
+                                                            "emit" => "sequence",
+                                                            "children" =>
+                                                                (value!([
+                                                                    (value!([
+                                                                        "emit" => "value_token_touch",
+                                                                        "value" => "Char"
+                                                                    ])),
+                                                                    (value!([
+                                                                        "emit" => "identifier",
+                                                                        "value" => "_"
+                                                                    ])),
+                                                                    (value!([
+                                                                        "emit" => "value_token_touch",
+                                                                        "value" => "<"
+                                                                    ])),
+                                                                    (value!([
+                                                                        "emit" => "identifier",
+                                                                        "value" => "Ccl"
+                                                                    ])),
+                                                                    (value!([
+                                                                        "emit" => "value_token_touch",
+                                                                        "value" => ">"
+                                                                    ])),
+                                                                    (value!([
+                                                                        "emit" => "call",
+                                                                        "children" =>
+                                                                            (value!([
+                                                                                (value!([
+                                                                                    "emit" => "identifier",
+                                                                                    "value" => "ast"
+                                                                                ])),
+                                                                                (value!([
+                                                                                    "emit" => "callarg",
+                                                                                    "children" =>
+                                                                                        (value!([
+                                                                                            "emit" => "value_string",
+                                                                                            "value" => "value_token_ccl"
+                                                                                        ]))
+                                                                                ]))
+                                                                            ]))
+                                                                    ]))
+                                                                ]))
+                                                        ])),
+                                                        (value!([
+                                                            "emit" => "sequence",
+                                                            "children" =>
+                                                                (value!([
+                                                                    (value!([
+                                                                        "emit" => "value_token_touch",
+                                                                        "value" => "."
+                                                                    ])),
+                                                                    (value!([
+                                                                        "emit" => "call",
+                                                                        "children" =>
+                                                                            (value!([
+                                                                                (value!([
+                                                                                    "emit" => "identifier",
+                                                                                    "value" => "ast"
+                                                                                ])),
+                                                                                (value!([
+                                                                                    "emit" => "callarg",
+                                                                                    "children" =>
+                                                                                        (value!([
+                                                                                            "emit" => "value_string",
+                                                                                            "value" => "value_token_any"
                                                                                         ]))
                                                                                 ]))
                                                                             ]))

--- a/src/compiler/tokay.tok
+++ b/src/compiler/tokay.tok
@@ -63,7 +63,7 @@ T_EscapeSequence : @{
     # fixme: In case when odd amount of digits is provided, a syntax error shall occur.
     #        This is like in Python: "\x2" SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 0-2: truncated \xXX escape
 
-    Any
+    Char
 }
 
 T_Identifier : @{

--- a/src/compiler/tokay.tok
+++ b/src/compiler/tokay.tok
@@ -106,7 +106,7 @@ T_Float : @{
 
 CclChar : @{
     '\\' T_EscapeSequence
-    [^\]]
+    [^\]\>]
     EOF  error("Unclosed character-class, expecting ']'")
 }
 
@@ -234,8 +234,9 @@ CallArguments : @{
 TokenLiteral : @{
     '\'' T_Touch '\''  ast("value_token_match")
     T_Touch  ast("value_token_touch")
-    '.'  ast("value_token_any")
     '[' Ccl ']'  ast("value_token_ccl")
+    'Char' _ '<' Ccl '>'  ast("value_token_ccl")
+    '.'  ast("value_token_any")
 }
 
 TokenAtom : @{
@@ -416,3 +417,4 @@ Tokay : @{
 }
 
 _ Tokay? expect EOF  ast("main")
+#_ Tokay? expect EOF  ast_print(ast("main"))

--- a/src/compiler/tokay.tok
+++ b/src/compiler/tokay.tok
@@ -5,8 +5,8 @@
 # Whitespace & EOL
 
 _ : @{  # true whitespace is made of comments and escaped line-breaks as well
-    [\t ]+
-    '#' [^\n]*
+    Char<\t >+
+    '#' Char<^\n>*
     '\\' '\r'? '\n'
 }
 
@@ -15,7 +15,7 @@ ___ : (T_EOL _)*  # optional line-breaks followed by whitespace
 _standalone_ : @{
     # helper parselet to ensure that identifiers stand alone
     # fixme: When generic parselets are available, this can be replaced by a Standalone<K> invocation
-    peek not [A-Z_a-z] _
+    peek not Char<A-Z_a-z> _
     _
 }
 
@@ -29,9 +29,9 @@ T_EOL : @{
 
 # Prime Tokens
 
-T_OctDigit : [0-7]
+T_OctDigit : Char<0-7>
 
-T_HexDigit : [0-9A-Fa-f]
+T_HexDigit : Char<0-9A-Fa-f>
 
 T_EscapeSequence : @{
     # Named escape sequences
@@ -71,17 +71,17 @@ T_Identifier : @{
 }
 
 T_Consumable : @{
-    [A-Z_] [0-9A-Z_a-z]*  ast("identifier", $0)
+    Char<A-Z_> Char<0-9A-Z_a-z>*  ast("identifier", $0)
 }
 
 T_Alias : @{
-    [A-Z_a-z] [0-9A-Z_a-z]*  ast("value_string", $0)
+    Char<A-Z_a-z> Char<0-9A-Z_a-z>*  ast("value_string", $0)
 }
 
 T_String : @{
     '"' {
         '\\' T_EscapeSequence
-        [^\\\"]
+        Char<^\\\">
         EOF  error("Unclosed string, expecting '\"'")
     }*  str_join("", $2) expect '"'
 }
@@ -89,7 +89,7 @@ T_String : @{
 T_Touch : @{
     '\'' {
         '\\' T_EscapeSequence
-        [^\\\']
+        Char<^\\\'>
         EOF  error("Unclosed match, expecting '\''")
     }*  str_join("", $2) expect '\''
 }
@@ -106,7 +106,7 @@ T_Float : @{
 
 CclChar : @{
     '\\' T_EscapeSequence
-    [^\]\>]
+    Char<^\>>
     EOF  error("Unclosed character-class, expecting ']'")
 }
 
@@ -234,9 +234,8 @@ CallArguments : @{
 TokenLiteral : @{
     '\'' T_Touch '\''  ast("value_token_match")
     T_Touch  ast("value_token_touch")
-    '[' Ccl ']'  ast("value_token_ccl")
     'Char' _ '<' Ccl '>'  ast("value_token_ccl")
-    '.'  ast("value_token_any")
+    'Char'  ast("value_token_any")
 }
 
 TokenAtom : @{
@@ -413,7 +412,7 @@ Nop : Void ast("op_nop")
 
 Tokay : @{
     Instruction+
-    .  error("Parse error, unexpected token", true)
+    Char  error("Parse error, unexpected token", true)
 }
 
 _ Tokay? expect EOF  ast("main")

--- a/src/value/token.rs
+++ b/src/value/token.rs
@@ -58,7 +58,6 @@ impl Token {
         }
 
         match ident {
-            "Any" => Some(Token::any()),
             "EOF" => Some(Token::EOF),
             "Void" => Some(Token::Void),
             ident => builtin_ccl(ident),

--- a/tests/compiler_identifiers.tok
+++ b/tests/compiler_identifiers.tok
@@ -1,7 +1,7 @@
 Pi : 3.1415  # Error: Cannot assign non-consumable to consumable constant.
 pi : 3.1415  # Ok
 
-Cident : [A-Za-z_] [A-Za-z0-9_]* $0
+Cident : Char<A-Za-z_> Char<A-Za-z0-9_>* $0
 cident : Cident  # Error: Cannot assign consumable to non-consumable constant.
 NewCident : Cident  # Ok
 

--- a/tests/token_modifiers.tok
+++ b/tests/token_modifiers.tok
@@ -7,9 +7,9 @@
 'a' ''b''+  # Match with positive modifier
 ''a''* ''b''+  # Match with kleene and positive modifiers
 'a'* ''b''+  # Touch with kleene and positive modifiers
-[a-z]
-[a-z]+
-[^ ']+
+Char<a-z>
+Char<a-z>+
+Char<^ '>+
 Int
 
 # Parsing with sequences and modifiers

--- a/tests/unescaping.tok
+++ b/tests/unescaping.tok
@@ -5,7 +5,7 @@
 'D' ''hello\nworld''
 'E' ''hello\\nworld''
 'F' ''hello\u20acworld''
-'G' [0-9\u20ac]+
+'G' Char<0-9\u20ac>+
 #---
 #A
 #B


### PR DESCRIPTION
This PR replaces the given `[...]`-syntax by a new syntax `Char<...>` for the following reasons:

1. The `[...]` syntax should become valid to specify lists
2. Tokay is by-design a programming language, not a parser generator. The usage of character-class definitions is generally kept low, so the tradeoff is clear; Lists will be defined and used more often than character-classes.
3. The new `Char` keyword underlines the future support of generics; A `Char` is generally any character. A `Char<...>` is a generalization of the character to a specific class. As this feature is built-in and generates statics, having its own syntax is valid.

This PR substitutes...
- ... the syntax `[...]` by `Char<...>` 
- ... the `.` previously specifying any character by `Char`
- ... the `Any` builtin token by `Char`

It generally cleans up the concept of characters and character-classes in the Tokay language.