### PR TITLE
Context-based stacks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn repl(opts: &Opts) {
 
                     let mut thread = Thread::new(&program, readers.iter_mut().collect());
                     thread.debug = compiler.debug;
-                    thread.load_stack(globals);
+                    thread.globals = globals;
 
                     match thread.run() {
                         Ok(Some(value)) => println!("{}", value.repr()),
@@ -162,7 +162,7 @@ fn repl(opts: &Opts) {
                         _ => {}
                     }
 
-                    globals = thread.save_stack();
+                    globals = thread.globals;
                 }
                 Err(errors) => {
                     for error in errors {

--- a/src/value/method.rs
+++ b/src/value/method.rs
@@ -44,8 +44,8 @@ impl Object for Method {
         nargs: Option<Dict>,
     ) -> Result<Accept, Reject> {
         // A method call injects the relating "this" object into the stack and calls the method afterwards.
-        context.thread.stack.insert(
-            context.thread.stack.len() - args,
+        context.stack.insert(
+            context.stack.len() - args,
             Capture::Value(self.object.clone(), None, 0),
         );
 

--- a/src/value/parselet.rs
+++ b/src/value/parselet.rs
@@ -75,7 +75,7 @@ impl Parselet {
     pub fn run(
         &self,
         thread: &mut Thread,
-        args: usize,
+        mut args: Vec<Capture>,
         mut nargs: Option<Dict>,
         main: bool,
         depth: usize,
@@ -87,105 +87,103 @@ impl Parselet {
         if self.consuming.is_some() {
             let reader_start = thread.reader.tell();
 
-            // Check for a previously memoized result in memo table
+            // Check for a previously memoized result
+            // fixme: This doesn't recognize calls to the same parselet with same parameters,
+            //        which might lead in unwanted results. This must be checked! It might become
+            //        a problem when the Repeat<P>(min=0, max=void) generic parselet becomes available.
             if let Some((reader_end, result)) = thread.memo.get(&(reader_start.offset, id)) {
                 thread.reader.reset(*reader_end);
                 return result.clone();
             }
         }
 
-        // If not, open a new context.
-        let mut context = Context::new(thread, self, args, depth);
+        if main {
+            assert!(self.signature.is_empty());
+            thread.globals.resize(self.locals, crate::value!(void));
+        }
 
-        if !main {
-            // Check for provided argument count bounds first
-            // todo: Not executed when *args-catchall is implemented
-            if args > self.signature.len() {
-                return Err(match self.signature.len() {
+        let args_len = args.len();
+
+        // Check for provided argument count bounds first
+        // todo: Not executed when *args-catchall is implemented
+        if args_len > self.signature.len() {
+            return Err(match self.signature.len() {
+                0 => format!(
+                    "{}() doesn't accept any arguments ({} given)",
+                    self.name, args_len
+                ),
+                1 => format!(
+                    "{}() takes exactly one argument ({} given)",
+                    self.name, args_len
+                ),
+                _ => format!(
+                    "{}() expected at most {} arguments ({} given)",
+                    self.name,
+                    self.signature.len(),
+                    args_len
+                ),
+            }
+            .into())
+            .into();
+        }
+
+        // Initialize local variables
+        args.resize(self.locals, Capture::Empty);
+
+        // Set remaining parameters to their defaults
+        for (i, arg) in (&self.signature[args_len..]).iter().enumerate() {
+            // args parameters are previously pushed onto the stack.
+            let var = &mut args[args_len + i];
+
+            //println!("{} {:?} {:?}", i, arg, var);
+            if matches!(var, Capture::Empty) {
+                // In case the parameter is empty, try to get it from nargs...
+                if let Some(ref mut nargs) = nargs {
+                    if let Some(value) = nargs.remove_str(&arg.0) {
+                        *var = Capture::Value(value, None, 0);
+                        continue;
+                    }
+                }
+
+                // Otherwise, use default value if available.
+                if let Some(addr) = arg.1 {
+                    // fixme: This might leak the immutable static value to something mutable...
+                    *var = Capture::Value(thread.program.statics[addr].clone(), None, 0);
+                    //println!("{} receives default {:?}", arg.0, var);
+                    continue;
+                }
+
+                return Error::new(
+                    None,
+                    format!("{}() expected argument '{}'", self.name, arg.0),
+                )
+                .into();
+            }
+        }
+
+        // Check for remaining nargs
+        // todo: Not executed when **nargs-catchall is implemented
+        if let Some(mut nargs) = nargs {
+            if let Some((name, _)) = nargs.pop() {
+                return Err(match nargs.len() {
                     0 => format!(
-                        "{}() doesn't accept any arguments ({} given)",
-                        self.name, args
-                    ),
-                    1 => format!(
-                        "{}() takes exactly one argument ({} given)",
-                        self.name, args
-                    ),
-                    _ => format!(
-                        "{}() expected at most {} arguments ({} given)",
+                        "{}() doesn't accept named argument '{}'",
                         self.name,
-                        self.signature.len(),
-                        args
+                        name.to_string()
+                    ),
+                    n => format!(
+                        "{}() doesn't accept named arguments ({} given)",
+                        self.name,
+                        n + 1
                     ),
                 }
                 .into())
                 .into();
             }
-
-            // Set remaining parameters to their defaults
-            for (i, arg) in (&self.signature[args..]).iter().enumerate() {
-                // args parameters are previously pushed onto the stack.
-                let var = &mut context.thread.stack[context.stack_start + args + i];
-
-                //println!("{} {:?} {:?}", i, arg, var);
-                if matches!(var, Capture::Empty) {
-                    // In case the parameter is empty, try to get it from nargs...
-                    if let Some(ref mut nargs) = nargs {
-                        if let Some(value) = nargs.remove_str(&arg.0) {
-                            *var = Capture::Value(value, None, 0);
-                            continue;
-                        }
-                    }
-
-                    // Otherwise, use default value if available.
-                    if let Some(addr) = arg.1 {
-                        // fixme: This might leak the immutable static value to something mutable...
-                        *var =
-                            Capture::Value(context.thread.program.statics[addr].clone(), None, 0);
-                        //println!("{} receives default {:?}", arg.0, var);
-                        continue;
-                    }
-
-                    return Error::new(
-                        None,
-                        format!("{}() expected argument '{}'", self.name, arg.0),
-                    )
-                    .into();
-                }
-            }
-
-            // Check for remaining nargs
-            // todo: Not executed when **nargs-catchall is implemented
-            if let Some(mut nargs) = nargs {
-                if let Some((name, _)) = nargs.pop() {
-                    return Err(match nargs.len() {
-                        0 => format!(
-                            "{}() doesn't accept named argument '{}'",
-                            self.name,
-                            name.to_string()
-                        ),
-                        n => format!(
-                            "{}() doesn't accept named arguments ({} given)",
-                            self.name,
-                            n + 1
-                        ),
-                    }
-                    .into())
-                    .into();
-                }
-            }
-        } else
-        /* main */
-        {
-            assert!(self.signature.len() == 0)
         }
 
-        // Initialize locals
-        for i in 0..self.locals {
-            if let Capture::Empty = context.thread.stack[context.stack_start + i] {
-                context.thread.stack[context.stack_start + i] =
-                    Capture::Value(crate::value!(void), None, 0);
-            }
-        }
+        // Create a new conrext
+        let mut context = Context::new(thread, self, depth, args);
 
         //println!("remaining {:?}", nargs);
         let reader_start = context.frame0().reader_start;
@@ -244,9 +242,8 @@ impl Parselet {
 
                 // Reset reader & stack
                 context.thread.reader.reset(reader_start);
-                context.thread.stack.truncate(context.stack_start); //fixme: context.frame0()?
+                context.stack.clear();
                 context
-                    .thread
                     .stack
                     .resize(context.frame0().capture_start, Capture::Empty);
             }
@@ -288,11 +285,6 @@ impl Parselet {
             }
         }
         */
-
-        if main {
-            // main parselet keeps locals on stack
-            context.stack_start += self.locals;
-        }
 
         result
     }
@@ -341,17 +333,15 @@ impl Object for ParseletRef {
         nargs: Option<Dict>,
     ) -> Result<Accept, Reject> {
         match context {
-            Some(context) => {
-                let len = args.len();
-                for arg in args {
-                    //context.push(arg)?;  //yeah...doesn't work...GRRR
-                    context.thread.stack.push(Capture::Value(arg, None, 0));
-                }
-
-                self.0
-                    .borrow()
-                    .run(context.thread, len, nargs, false, context.depth + 1)
-            }
+            Some(context) => self.0.borrow().run(
+                context.thread,
+                args.into_iter()
+                    .map(|arg| Capture::Value(arg, None, 0))
+                    .collect(),
+                nargs,
+                false,
+                context.depth + 1,
+            ),
             None => panic!("{} needs a context to operate", self.repr()),
         }
     }
@@ -362,9 +352,13 @@ impl Object for ParseletRef {
         args: usize,
         nargs: Option<Dict>,
     ) -> Result<Accept, Reject> {
-        self.0
-            .borrow()
-            .run(context.thread, args, nargs, false, context.depth + 1)
+        self.0.borrow().run(
+            context.thread,
+            context.stack.split_off(context.stack.len() - args),
+            nargs,
+            false,
+            context.depth + 1,
+        )
     }
 }
 

--- a/src/vm/context.rs
+++ b/src/vm/context.rs
@@ -39,12 +39,10 @@ pub struct Context<'program, 'reader, 'thread, 'parselet> {
     pub parselet: &'parselet Parselet,                  // Current parselet
     pub depth: usize,                                   // Recursion depth
 
-    // Positions
-    pub stack_start: usize, // Stack start (including locals and parameters)
-
     // Virtual machine
-    pub frames: Vec<Frame>, // Frame stack
-    pub frame: Frame,       // Current frame
+    pub stack: Vec<Capture>, // Capture stack
+    pub frames: Vec<Frame>,  // Frame stack
+    pub frame: Frame,        // Current frame
 
     pub loops: Vec<Loop>, // Loop stack
 
@@ -56,28 +54,14 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
     pub fn new(
         thread: &'thread mut Thread<'program, 'reader>,
         parselet: &'parselet Parselet,
-        take: usize,
         depth: usize,
+        mut stack: Vec<Capture>,
     ) -> Self {
-        let stack_start = thread.stack.len() - take;
+        stack.push(Capture::Empty); // Initialize $0
 
-        /*
-        println!("--- {:?} ---", parselet.name);
-        println!("stack = {:#?}", thread.stack);
-        println!("stack = {:?}", thread.stack.len());
-        println!("start = {:?}", stack_start);
-        println!("resize = {:?}", stack_start + locals + 1);
-        */
-
-        // Initialize local variables and $0
-        thread
-            .stack
-            .resize(stack_start + parselet.locals + 1, Capture::Empty);
-
-        // Create context frame0
         let frame = Frame {
             fuse: None,
-            capture_start: stack_start + parselet.locals + 1,
+            capture_start: parselet.locals + 1,
             reader_start: thread.reader.tell(),
         };
 
@@ -86,8 +70,9 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
             thread,
             parselet,
             depth,
-            stack_start,
+            stack,
             frames: Vec::new(),
+            // Create context frame0
             frame,
             loops: Vec::new(),
             source_offset: None,
@@ -123,7 +108,7 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
     #[inline]
     pub fn pop(&mut self) -> RefValue {
         // todo: check for context limitations on the stack?
-        let mut capture = self.thread.stack.pop().unwrap();
+        let mut capture = self.stack.pop().unwrap();
         capture.extract(&mut self.thread.reader)
     }
 
@@ -131,14 +116,14 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
     #[inline]
     pub fn peek(&mut self) -> RefValue {
         // todo: check for context limitations on the stack?
-        let capture = self.thread.stack.last_mut().unwrap();
+        let capture = self.stack.last_mut().unwrap();
         capture.extract(&mut self.thread.reader)
     }
 
     // Push a value onto the stack
     #[inline]
     pub fn load(&mut self, index: usize) -> Result<Accept, Reject> {
-        let capture = &mut self.thread.stack[index];
+        let capture = &mut self.stack[index];
         let value = capture.extract(&self.thread.reader);
         self.push(value)
     }
@@ -146,8 +131,8 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
     // Reset context stack state
     #[inline]
     fn reset(&mut self, offset: Option<Offset>) {
-        self.thread.stack.truncate(self.frame.capture_start - 1); // Truncate stack including $0
-        self.thread.stack.push(Capture::Empty); // re-initialize $0
+        self.stack.truncate(self.frame.capture_start - 1); // Truncate stack including $0
+        self.stack.push(Capture::Empty); // re-initialize $0
 
         if let Some(offset) = offset {
             self.frame.reader_start = offset; // Set reader start to provided position
@@ -180,13 +165,13 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
 
         let pos = capture_start + pos - 1;
 
-        if pos >= self.thread.stack.len() {
+        if pos >= self.stack.len() {
             None
         }
         // This is $0?
         else if pos < capture_start {
             // Capture 0 either returns an already set value or ...
-            if let Capture::Value(value, ..) = &self.thread.stack[pos] {
+            if let Capture::Value(value, ..) = &self.stack[pos] {
                 return Some(value.clone());
             }
 
@@ -198,18 +183,18 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
             ))
         // Any other index.
         } else {
-            self.thread.stack[pos].degrade();
-            Some(self.thread.stack[pos].extract(&self.thread.reader))
+            self.stack[pos].degrade();
+            Some(self.stack[pos].extract(&self.thread.reader))
         }
     }
 
     /** Return a capture by name as RefValue. */
     pub fn get_capture_by_name(&mut self, name: &str) -> Option<RefValue> {
         let capture_start = self.frame0().capture_start;
-        let tos = self.thread.stack.len();
+        let tos = self.stack.len();
 
         for i in (0..tos - capture_start).rev() {
-            let capture = &mut self.thread.stack[capture_start + i];
+            let capture = &mut self.stack[capture_start + i];
 
             if capture.alias(name) {
                 capture.degrade();
@@ -225,11 +210,11 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
         let capture_start = self.frame0().capture_start;
         let pos = capture_start + pos - 1;
 
-        if pos >= self.thread.stack.len() {
+        if pos >= self.stack.len() {
             return;
         }
 
-        let capture = &mut self.thread.stack[pos];
+        let capture = &mut self.stack[pos];
 
         // $0 gets a higher severity than normal captures.
         let severity = if pos < capture_start { 10 } else { 5 };
@@ -248,10 +233,10 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
     /** Set a capture to a RefValue by name. */
     pub fn set_capture_by_name(&mut self, name: &str, value: RefValue) {
         let capture_start = self.frame0().capture_start;
-        let tos = self.thread.stack.len();
+        let tos = self.stack.len();
 
         for i in (0..tos - capture_start).rev() {
-            let capture = &mut self.thread.stack[capture_start + i];
+            let capture = &mut self.stack[capture_start + i];
 
             if capture.alias(name) {
                 match capture {
@@ -288,7 +273,7 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
         debug: bool,          // Print debug information
     ) -> Capture {
         // Early abort when capture_start is behind stack len
-        if capture_start > self.thread.stack.len() {
+        if capture_start > self.stack.len() {
             return Capture::Empty;
         }
 
@@ -298,14 +283,13 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
         let captures: Vec<Capture> = if copy {
             // fixme: copy feature isn't used...
             Vec::from_iter(
-                self.thread.stack[capture_start..]
+                self.stack[capture_start..]
                     .iter()
                     .filter(|item| !(matches!(item, Capture::Empty)))
                     .cloned(),
             )
         } else {
-            self.thread
-                .stack
+            self.stack
                 .drain(capture_start..)
                 .filter(|item| !(matches!(item, Capture::Empty)))
                 .collect()
@@ -428,11 +412,10 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
 
     /// Drains n items off the stack into a vector of values
     pub fn drain(&mut self, n: usize) -> Vec<RefValue> {
-        let tos = self.thread.stack.len();
+        let tos = self.stack.len();
         assert!(n <= tos - self.frame0().capture_start);
 
         let captures: Vec<Capture> = self
-            .thread
             .stack
             .drain(tos - n..)
             .filter(|capture| !matches!(capture, Capture::Empty))
@@ -453,18 +436,17 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
             // In case state is Accept::Next, try to return a capture
             Ok(Accept::Next) => {
                 // Either take $0 when set
-                if let Capture::Value(value, ..) =
-                    &mut self.thread.stack[self.frame.capture_start - 1]
-                {
+                if let Capture::Value(value, ..) = &mut self.stack[self.frame.capture_start - 1] {
                     state = Ok(Accept::Push(Capture::Value(
                         value.clone(),
                         None,
                         self.parselet.severity,
                     )));
                 // Otherwise, push last value
-                } else if self.thread.stack.len() > self.frame.capture_start {
-                    state = Ok(Accept::Push(self.thread.stack.pop().unwrap())
-                        .into_push(self.parselet.severity));
+                } else if self.stack.len() > self.frame.capture_start {
+                    state =
+                        Ok(Accept::Push(self.stack.pop().unwrap())
+                            .into_push(self.parselet.severity));
                 }
             }
 
@@ -682,13 +664,5 @@ impl<'program, 'reader, 'thread, 'parselet> Context<'program, 'reader, 'thread, 
         } else {
             Ok(Accept::Push(Capture::Empty))
         }
-    }
-}
-
-impl<'program, 'reader, 'thread, 'parselet> Drop
-    for Context<'program, 'reader, 'thread, 'parselet>
-{
-    fn drop(&mut self) {
-        self.thread.stack.truncate(self.stack_start);
     }
 }


### PR DESCRIPTION
This Pull Request enforces that there's no global stack in Thread anymore, but a stack on every context.
This doesn't grow the stack in one big Vec, but splits it into they individual contexts.
Stacks are kept separate, for security and modularity.