### PR TITLE
fix: Resolve recursive self-references to `ImlValue::SelfToken`

### DIFF
--- a/src/compiler/iml/imlvalue.rs
+++ b/src/compiler/iml/imlvalue.rs
@@ -105,7 +105,7 @@ impl ImlValue {
                         None
                     }
                 }
-                Err(_) => todo!("Recursive resolve() impossible by design, see bug #127"),
+                Err(_) => Some(ImlValue::SelfToken),
             },
             Self::Name { offset, name, .. } => scope.resolve_name(offset.clone(), &name),
             Self::Instance {

--- a/tests/parselet_generic_selfref.tok
+++ b/tests/parselet_generic_selfref.tok
@@ -7,6 +7,8 @@ X: @<X> {
 Y<'a'> print("Ja!")
 X<'x'> print("Jx!")
 #---
-#ERR:SKIP
-#ERR:not yet implemented: Recursive resolve() impossible by design, see bug #127
-#ERR:SKIP
+#xaxxxx
+#---
+#Ja!
+#Jx!
+#Jx!


### PR DESCRIPTION
This is a proposal, which seems to fix #127.